### PR TITLE
Resolve Battery level indicator not showing on 100%

### DIFF
--- a/scripts/battery_level.sh
+++ b/scripts/battery_level.sh
@@ -8,6 +8,8 @@ CHARGE="100"
 
 if [ "$VAR1" = "$VAR2" ]; then
     CHARGE=${BATTERY_INFO[4]//%}
+elif [ "${BATTERY_INFO[3]}" = "100%" ]; then
+    CHARGE=$((${BATTERY_INFO[3]//%}))
 else
     CHARGE=$((${BATTERY_INFO[3]//%,}))
 fi


### PR DESCRIPTION
When the battery is at 100%, the output doesn't have the `,` unlike at other times. This leads to the script not showing the output for 100% and plugged in.

With this statement to cover this case, it should work well.

Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>